### PR TITLE
Pack check fails if data.creatures isnt an array.

### DIFF
--- a/src/summon/menu/SummoningMenu.svelte
+++ b/src/summon/menu/SummoningMenu.svelte
@@ -43,7 +43,7 @@
 		data.creatures = loadPacks();
 	} else if (data.creatures instanceof CompendiumCollection) {
 		data.creatures = loadPacks(false, false, [data.creatures.metadata]);
-	} else if (data.creatures.some((pack) => pack instanceof CompendiumCollection)) {
+	} else if (data.creatures.some && data.creatures.some((pack) => pack instanceof CompendiumCollection)) {
 		data.creatures = new Promise((resolveOuter) => {
 			data.creatures = data.creatures.map(async (pack) => {
 				if (pack instanceof CompendiumCollection) {


### PR DESCRIPTION
Addresses bug opened here: https://github.com/MrVauxs/foundry-summons/issues/28

This is a simple fix to keep the flow moving on.